### PR TITLE
The content-addressed storage is now a tiny lib.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,10 +317,8 @@ dependencies = [
  "clap",
  "dotenvy",
  "env_logger 0.10.0",
- "hex",
  "log",
  "mdns-sd",
- "sha2",
  "tokio",
  "tokio-util",
  "utils",
@@ -1143,6 +1141,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b24dd0826eee92c56edcda7ff190f2cf52115c49eadb2c2da8063e2673a8c2"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,7 +1380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b070a70988c737646f0ff395f4317934c4a90ec14910477e3d1d5a5e22f60d"
 dependencies = [
  "flume",
- "if-addrs",
+ "if-addrs 0.7.0",
  "log",
  "polling",
  "socket2",
@@ -1844,9 +1852,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2106,6 +2114,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
  "utils",
  "uuid",
 ]
@@ -2551,10 +2560,16 @@ name = "utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "if-addrs",
+ "hex",
+ "if-addrs 0.8.0",
  "log",
  "mdns-sd",
+ "serde",
+ "serde_json",
+ "sha2",
  "thiserror",
+ "tokio",
+ "tokio-util",
  "wasi-common",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ dotenvy = "0.15.6"
 env_logger = "0.10.0"
 log = "0.4.17"
 mdns-sd = { version = "0.5.9", default-features = false, features = ["async"] }
+serde = { version = "1.0.149", features = ["derive"] }
+serde_json = "1.0.89"
 tokio = { version = "1.22.0", features = ["full"] }
 tokio-util = { version = "0.7.4", features = ["io"] }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }

--- a/castaway/Cargo.toml
+++ b/castaway/Cargo.toml
@@ -12,10 +12,8 @@ axum = { workspace = true }
 clap = { workspace = true }
 dotenvy = { workspace = true }
 env_logger = { workspace = true }
-hex = "0.4.3"
 log = { workspace = true }
 mdns-sd = "0.5.9"
-sha2 = "0.10.6"
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 utils = { path = "../utils" }

--- a/serval-agent/Cargo.toml
+++ b/serval-agent/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4.17"
 reqwest = { version = "0.11.13",  default-features = false, features = ["brotli", "json", "rustls"] }
 serde = { version = "1.0.149", features = ["serde_derive"] }
 serde_json = "1.0.89"
-tokio =  { version = "1.23.0", features = ["full"] }
+tokio =  { workspace = true }
+tokio-util = { workspace = true }
 utils = { path = "../utils" }
 uuid = { workspace = true }

--- a/serval-agent/src/api/jobs.rs
+++ b/serval-agent/src/api/jobs.rs
@@ -1,0 +1,152 @@
+use anyhow::Result;
+use axum::{
+    extract::{Multipart, Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use engine::ServalEngine;
+use utils::structs::WasmResult;
+
+use super::*;
+
+/// This is the main worker endpoint. It accepts incoming jobs and runs them.
+pub async fn incoming(state: State<AppState>, mut multipart: Multipart) -> Response {
+    let mut envelope: Option<Envelope> = None;
+    let mut binary: Option<Vec<u8>> = None;
+    let mut input: Option<Vec<u8>> = None;
+
+    // chomp up form input here
+    while let Some(field) = multipart.next_field().await.unwrap() {
+        let name = field.name().unwrap().to_string();
+        let data = field.bytes().await.unwrap();
+        match name.as_str() {
+            "envelope" => {
+                let data = data.to_vec();
+                let Ok(parsed) = serde_json::from_slice(&data) else {
+                    // this is not good enough
+                    return (StatusCode::BAD_REQUEST, "job envelope is invalid".to_string()).into_response();
+                };
+                envelope = Some(parsed);
+            }
+            "input" => {
+                input = Some(data.to_vec());
+            }
+            "executable" => {
+                binary = Some(data.to_vec());
+            }
+            _ => {
+                log::info!("ignoring unknown field `{name}`");
+            }
+        }
+    }
+
+    if binary.is_none() {
+        return (
+            StatusCode::BAD_REQUEST,
+            "no wasm executable data provided!".to_string(),
+        )
+            .into_response();
+    }
+
+    let envelope = envelope.unwrap_or(Envelope {
+        name: "unknown".to_string(),
+        description: "unknown job description".to_string(),
+    });
+    let metadata: JobMetadata = JobMetadata::from(envelope);
+    let binary = binary.unwrap();
+    log::info!(
+        "received WASM job; name={}; executable length={}; input length={}",
+        metadata.name,
+        binary.len(),
+        input.as_ref().map(|input| input.len()).unwrap_or_else(|| 0),
+    );
+
+    run_job_inner(state, metadata, binary, input).await
+}
+
+async fn run_job_inner(
+    state: State<AppState>,
+    metadata: JobMetadata,
+    binary: Vec<u8>,
+    input: Option<Vec<u8>>,
+) -> Response {
+    let mut state = state.lock().await;
+
+    // Poor human's history tracking here. We'll need to do better at some point.
+    // E.g., handle overflows. That would be some nice uptime.
+    state.total += 1;
+    state.jobs.insert(metadata.id.to_string(), metadata.clone());
+
+    let start = std::time::Instant::now();
+
+    // What we'll do later is accept this job for processing and send it to a thread or something.
+    // But for now we do it right here, in our handler.
+    // The correct response by design is a 202 Accepted plus the metadata object.
+    // TODO: SER-38 - capture exit code for failed jobs
+    log::info!(
+        "about to run job name={}; id={}; executable size={}",
+        metadata.name,
+        metadata.id,
+        binary.len()
+    );
+    match execute_job(binary, input).await {
+        Ok(result) => {
+            // We're not doing anything with stderr here.
+            log::info!(
+                "job completed; job={}; code={}; elapsed_ms={}",
+                metadata.id,
+                result.code,
+                start.elapsed().as_millis()
+            );
+            if result.code == 0 {
+                // Zero exit status code is a success.
+                (StatusCode::OK, result.stdout).into_response()
+            } else {
+                // Now the fun part of http error signaling: the request was successful, but the
+                // result of the operation was bad from the user's point of view. Our behavior here
+                // is yet to be defined but I'm sending back stderr just to show we can.
+                (StatusCode::OK, result.stderr).into_response()
+            }
+        }
+        Err(e) => {
+            state.errors += 1;
+            (StatusCode::BAD_REQUEST, e.to_string()).into_response()
+        }
+    }
+}
+
+/// Run a job in the wasm engine.
+// Probably can vanish because there's only one caller.
+async fn execute_job(executable: Vec<u8>, input: Option<Vec<u8>>) -> Result<WasmResult> {
+    let stdin = input.unwrap_or_default();
+
+    let mut engine = ServalEngine::new()?;
+    let result = engine.execute(&executable, &stdin)?;
+
+    Ok(result)
+}
+
+/// Run a previously-stored job by address. Fast hack. Feel free to improve with an input feature.
+pub async fn run_stored_job(
+    state: State<AppState>,
+    Path(blob_addr): Path<String>,
+) -> impl IntoResponse {
+    let locked = state.lock().await;
+    let Ok(binary) = locked.storage.get_bytes(&blob_addr).await else {
+        return (
+            StatusCode::NOT_FOUND,
+            format!("Blob {} not found", &blob_addr),
+        )
+            .into_response();
+    };
+
+    let metadata = JobMetadata::new(blob_addr.clone(), "stored binary".to_string());
+    drop(locked);
+    run_job_inner(state, metadata, binary, None).await
+}
+
+pub async fn monitor_history(state: State<AppState>) -> Json<RunnerState> {
+    let state = state.lock().await;
+    Json(state.clone())
+}

--- a/serval-agent/src/api/mod.rs
+++ b/serval-agent/src/api/mod.rs
@@ -1,0 +1,94 @@
+use anyhow::Result;
+use axum::{
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::Response,
+};
+use http::header::HeaderValue;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use utils::blobs::BlobStore;
+use uuid::Uuid;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub mod jobs;
+pub mod storage;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RunnerState {
+    storage: BlobStore,
+    jobs: HashMap<String, JobMetadata>,
+    total: usize,
+    errors: usize,
+}
+
+impl RunnerState {
+    pub fn new(blob_path: String) -> Self {
+        RunnerState {
+            storage: BlobStore::new(blob_path.into()),
+            total: 0,
+            errors: 0,
+            jobs: HashMap::new(),
+        }
+    }
+}
+
+pub type AppState = Arc<Mutex<RunnerState>>;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JobMetadata {
+    id: Uuid,
+    name: String,
+    description: String,
+    status_url: String, // for the moment
+    result_url: String, // for the moment
+}
+
+impl JobMetadata {
+    pub fn new(name: String, description: String) -> Self {
+        let id = Uuid::new_v4();
+        Self {
+            id,
+            name,
+            description,
+            status_url: format!("/jobs/{}/status", id),
+            result_url: format!("/jobs/{}/result", id),
+        }
+    }
+}
+
+impl From<Envelope> for JobMetadata {
+    fn from(envelope: Envelope) -> Self {
+        let id = Uuid::new_v4();
+        Self {
+            id,
+            name: envelope.name.clone(),
+            description: envelope.description,
+            status_url: format!("/jobs/{}/status", id),
+            result_url: format!("/jobs/{}/result", id),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Envelope {
+    name: String,
+    description: String,
+}
+
+/// Remember what is important.
+pub async fn clacks<B>(req: Request<B>, next: Next<B>) -> Result<Response, StatusCode> {
+    let mut response = next.run(req).await;
+    response.headers_mut().append(
+        "X-Clacks-Overhead",
+        HeaderValue::from_static("GNU/Terry Pratchett"),
+    );
+    Ok(response)
+}
+
+/// Respond to ping. Useful for monitoring.
+pub async fn ping() -> String {
+    "pong".to_string()
+}

--- a/serval-agent/src/api/storage.rs
+++ b/serval-agent/src/api/storage.rs
@@ -1,0 +1,74 @@
+use axum::{
+    body::{Bytes, StreamBody},
+    extract::{Path, State},
+    http::{header, StatusCode},
+    response::IntoResponse,
+};
+
+use utils::errors::ServalError;
+
+use super::*;
+
+pub async fn get_blob(
+    Path(blob_addr): Path<String>,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    // Yeah, I don't like this.
+    let state = state.lock().await;
+
+    match state.storage.get_stream(&blob_addr).await {
+        Ok(stream) => {
+            let body = StreamBody::new(stream);
+            let headers = [(
+                header::CONTENT_TYPE,
+                String::from("application/octet-stream"),
+            )];
+
+            log::info!("Serving blob; addr={}", &blob_addr);
+            (headers, body).into_response()
+        }
+        Err(e) => match e {
+            ServalError::BlobAddressInvalid(_) => {
+                log::warn!("Request for an invalid address; addr={}", blob_addr);
+                StatusCode::BAD_REQUEST.into_response()
+            }
+            ServalError::BlobAddressNotFound(_) => {
+                log::warn!("Blob not found; addr={blob_addr}");
+                (
+                    StatusCode::NOT_FOUND,
+                    format!("Blob {} not found", &blob_addr),
+                )
+                    .into_response()
+            }
+            ServalError::IoError(_) => {
+                log::warn!("i/o error reading blob; addr={blob_addr}; {:?}", e);
+                (
+                    StatusCode::NOT_FOUND,
+                    format!("Blob {} not found", &blob_addr),
+                )
+                    .into_response()
+            }
+            _ => {
+                log::warn!("unexpected error case; addr={blob_addr}; {:?}", e);
+                StatusCode::INTERNAL_SERVER_ERROR.into_response()
+            }
+        },
+    }
+}
+
+pub async fn store_blob(State(state): State<AppState>, body: Bytes) -> impl IntoResponse {
+    // Yeah, I don't like this.
+    let state = state.lock().await;
+
+    match state.storage.store(&body).await {
+        Ok((new, address)) => {
+            log::info!("Stored blob; addr={} size={}", &address, body.len());
+            if new {
+                (StatusCode::CREATED, address).into_response()
+            } else {
+                (StatusCode::OK, address).into_response()
+            }
+        }
+        Err(_e) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}

--- a/serval-agent/src/main.rs
+++ b/serval-agent/src/main.rs
@@ -9,201 +9,20 @@
 
 use anyhow::Result;
 use axum::{
-    extract::{DefaultBodyLimit, Multipart, State},
-    http::{Request, StatusCode},
-    middleware::{self, Next},
-    response::{IntoResponse, Response},
-    routing::{get, post},
-    Json, Router,
+    extract::DefaultBodyLimit,
+    middleware::{self},
+    routing::{get, post, put},
+    Router,
 };
 use dotenvy::dotenv;
-use engine::ServalEngine;
-use http::header::HeaderValue;
-use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
-use utils::{mdns::advertise_service, structs::WasmResult};
-use uuid::Uuid;
+use utils::mdns::advertise_service;
 
-use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-#[derive(Clone, Serialize)]
-struct RunnerState {
-    jobs: HashMap<String, JobMetadata>,
-    total: usize,
-    errors: usize,
-}
-
-impl RunnerState {
-    pub fn new() -> Self {
-        RunnerState {
-            total: 0,
-            errors: 0,
-            jobs: HashMap::new(),
-        }
-    }
-}
-
-type AppState = Arc<Mutex<RunnerState>>;
-
-#[derive(Clone, Serialize, Deserialize)]
-struct JobMetadata {
-    id: Uuid,
-    name: String,
-    description: String,
-    status_url: String, // for the moment
-    result_url: String, // for the moment
-}
-
-impl From<Envelope> for JobMetadata {
-    fn from(envelope: Envelope) -> Self {
-        let id = Uuid::new_v4();
-        Self {
-            id,
-            name: envelope.name.clone(),
-            description: envelope.description,
-            status_url: format!("/jobs/{}/status", id),
-            result_url: format!("/jobs/{}/result", id),
-        }
-    }
-}
-
-/// Remember what is important.
-async fn clacks<B>(req: Request<B>, next: Next<B>) -> Result<Response, StatusCode> {
-    let mut response = next.run(req).await;
-    response.headers_mut().append(
-        "X-Clacks-Overhead",
-        HeaderValue::from_static("GNU/Terry Pratchett"),
-    );
-    Ok(response)
-}
-
-/// Respond to ping. Useful for monitoring.
-async fn ping() -> String {
-    "pong".to_string()
-}
-
-#[derive(Clone, Debug, Deserialize)]
-struct Envelope {
-    name: String,
-    description: String,
-}
-
-/// This is the main worker endpoint. It accepts incoming jobs and runs them.
-async fn incoming(state: State<AppState>, mut multipart: Multipart) -> Response {
-    let mut envelope: Option<Envelope> = None;
-    let mut binary: Option<Vec<u8>> = None;
-    let mut input: Option<Vec<u8>> = None;
-
-    // chomp up form input here
-    while let Some(field) = multipart.next_field().await.unwrap() {
-        let name = field.name().unwrap().to_string();
-        let data = field.bytes().await.unwrap();
-        match name.as_str() {
-            "envelope" => {
-                let data = data.to_vec();
-                let Ok(parsed) = serde_json::from_slice(&data) else {
-                    // this is not good enough
-                    return (StatusCode::BAD_REQUEST, "job envelope is invalid".to_string()).into_response();
-                };
-                envelope = Some(parsed);
-            }
-            "input" => {
-                input = Some(data.to_vec());
-            }
-            "executable" => {
-                binary = Some(data.to_vec());
-            }
-            _ => {
-                log::info!("ignoring unknown field `{name}`");
-            }
-        }
-    }
-
-    if binary.is_none() {
-        return (
-            StatusCode::BAD_REQUEST,
-            "no wasm executable data provided!".to_string(),
-        )
-            .into_response();
-    }
-
-    let envelope = envelope.unwrap_or(Envelope {
-        name: "unknown".to_string(),
-        description: "unknown job description".to_string(),
-    });
-    let metadata: JobMetadata = JobMetadata::from(envelope);
-    let binary = binary.unwrap();
-    log::info!(
-        "received WASM job; name={}; executable length={}; input length={}",
-        metadata.name,
-        binary.len(),
-        input.as_ref().map(|input| input.len()).unwrap_or_else(|| 0),
-    );
-
-    // Poor human's history tracking here. We'll need to do better at some point.
-    // E.g., handle overflows. That would be some nice uptime.
-    let mut state = state.lock().await;
-    state.total += 1;
-    state.jobs.insert(metadata.id.to_string(), metadata.clone());
-
-    let start = std::time::Instant::now();
-
-    // What we'll do later is accept this job for processing and send it to a thread or something.
-    // But for now we do it right here, in our handler.
-    // The correct response by design is a 202 Accepted plus the metadata object.
-    // TODO: SER-38 - capture exit code for failed jobs
-    match execute_job(&metadata, binary, input).await {
-        Ok(result) => {
-            // We're not doing anything with stderr here.
-            log::info!(
-                "job completed; job={}; code={}; elapsed_ms={}",
-                metadata.id,
-                result.code,
-                start.elapsed().as_millis()
-            );
-            if result.code == 0 {
-                // Zero exit status code is a success.
-                (StatusCode::OK, result.stdout).into_response()
-            } else {
-                // Now the fun part of http error signalling: the request was successful, but the
-                // result of the operation was bad from the user's point of view. Our behavior here
-                // is yet to be defined but I'm sending back stderr just to show we can.
-                (StatusCode::OK, result.stderr).into_response()
-            }
-        }
-        Err(e) => {
-            state.errors += 1;
-            (StatusCode::BAD_REQUEST, e.to_string()).into_response()
-        }
-    }
-}
-
-/// Run a job in the wasm engine.
-async fn execute_job(
-    metadata: &JobMetadata,
-    executable: Vec<u8>,
-    input: Option<Vec<u8>>,
-) -> Result<WasmResult> {
-    log::info!(
-        "about to run job name={}; id={}",
-        metadata.name,
-        metadata.id
-    );
-
-    let stdin = input.unwrap_or_default();
-
-    let mut engine = ServalEngine::new()?;
-    let result = engine.execute(&executable, &stdin)?;
-
-    Ok(result)
-}
-
-async fn monitor_history(state: State<AppState>) -> Json<RunnerState> {
-    let state = state.lock().await;
-    Json(state.clone())
-}
+mod api;
+use crate::api::*;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -214,14 +33,19 @@ async fn main() -> Result<()> {
     let port: u16 = std::env::var("PORT")
         .unwrap_or_else(|_| "8100".to_string())
         .parse()?;
+    let blob_path = std::env::var("BLOB_STORE").unwrap_or_else(|_| "/tmp".to_string());
 
-    let state = Arc::new(Mutex::new(RunnerState::new()));
+    log::info!("serval agent blob store mounted; path={blob_path}");
+    let state = Arc::new(Mutex::new(RunnerState::new(blob_path)));
 
     const MAX_BODY_SIZE_BYTES: usize = 10 * 1024 * 1024;
     let app = Router::new()
         .route("/monitor/ping", get(ping))
-        .route("/monitor/history", get(monitor_history))
-        .route("/jobs", post(incoming))
+        .route("/monitor/history", get(jobs::monitor_history))
+        .route("/jobs", post(jobs::incoming))
+        .route("/run/:addr", get(jobs::run_stored_job))
+        .route("/blobs", put(storage::store_blob))
+        .route("/blobs/:addr", get(storage::get_blob))
         .route_layer(middleware::from_fn(clacks))
         .layer(DefaultBodyLimit::max(MAX_BODY_SIZE_BYTES))
         .with_state(state);

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -8,8 +8,14 @@ license = "BSD-2-Clause-Patent"
 
 [dependencies]
 anyhow = { workspace = true }
-if-addrs = "0.7.0"
+hex = "0.4.3"
+if-addrs = "0.8.0"
 log = {workspace = true }
 mdns-sd = { workspace = true }
+sha2 = "0.10.6"
 thiserror = "1.0.38"
+tokio = { workspace = true }
+tokio-util = { workspace = true }
 wasi-common = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/utils/src/blobs.rs
+++ b/utils/src/blobs.rs
@@ -1,8 +1,8 @@
 use serde::Serialize;
 use sha2::{Digest, Sha256};
+use tokio::io::AsyncReadExt;
 use tokio::{fs::File, io::AsyncWriteExt};
 use tokio_util::io::ReaderStream;
-use tokio::io::AsyncReadExt;
 use tokio_util::io::StreamReader;
 
 use std::path::PathBuf;

--- a/utils/src/blobs.rs
+++ b/utils/src/blobs.rs
@@ -1,0 +1,86 @@
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use tokio::{fs::File, io::AsyncWriteExt};
+use tokio_util::io::ReaderStream;
+use tokio::io::AsyncReadExt;
+use tokio_util::io::StreamReader;
+
+use std::path::PathBuf;
+
+use crate::errors::ServalError;
+
+fn is_valid_address(addr: &str) -> bool {
+    // this does not seem worth adding a regexp crate for
+    let valid_chars = String::from("0123456789abcdef");
+    addr.len() == 64
+        && addr
+            .to_lowercase()
+            .chars()
+            .all(|ch| valid_chars.contains(ch))
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct BlobStore {
+    location: PathBuf,
+}
+
+impl BlobStore {
+    /// Create a new blob store, passing in a path to a writeable directory
+    pub fn new(location: PathBuf) -> Self {
+        Self { location }
+    }
+
+    /// Given a content address, return a read stream for the object stored there.
+    /// Responds with an error if no object is found or if the address is invalid.
+    pub async fn get_stream(&self, address: &str) -> Result<ReaderStream<File>, ServalError> {
+        if !is_valid_address(address) {
+            return Err(ServalError::BlobAddressInvalid(address.to_string()));
+        }
+
+        let filename = self.location.join(address);
+        if !filename.exists() {
+            return Err(ServalError::BlobAddressNotFound(address.to_string()));
+        }
+
+        let file = tokio::fs::File::open(filename).await?;
+        let stream = ReaderStream::new(file);
+        Ok(stream)
+    }
+
+    pub async fn get_bytes(&self, address: &str) -> Result<Vec<u8>, ServalError> {
+        let stream = self.get_stream(address).await?;
+        let mut reader = StreamReader::new(stream);
+        let mut binary = Vec::new();
+        let _count = reader.read_to_end(&mut binary).await;
+        Ok(binary)
+    }
+
+    /// Store an object in our blob store.
+    pub async fn store(&self, body: &[u8]) -> Result<(bool, String), ServalError> {
+        let mut hasher = Sha256::new();
+        hasher.update(body);
+        let blob_addr = hex::encode(hasher.finalize());
+        let filename = self.location.join(&blob_addr);
+        if filename.exists() {
+            return Ok((false, blob_addr));
+        }
+
+        let mut file = tokio::fs::File::create(filename).await?;
+        file.write_all(body).await?;
+        Ok((true, blob_addr))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::blobs::is_valid_address;
+
+    #[test]
+    fn valid_and_invalid_addresses() {
+        assert!(is_valid_address(
+            "25449ceed05926fc81700a3e8b66f66291ba9ed67dea9af88f83647ddb40e2f3"
+        ));
+        assert!(!is_valid_address("deadbeef"));
+        assert!(!is_valid_address("invalid characters"));
+    }
+}

--- a/utils/src/errors.rs
+++ b/utils/src/errors.rs
@@ -31,4 +31,16 @@ pub enum ServalError {
     /// The WASMtime engine responded with an error.
     #[error("wasmtime engine error")]
     WasmEngineError(#[from] wasi_common::Error),
+
+    /// The caller has attempted to load an object from the blob store with an invalid address.
+    #[error("blob address is not a valid hex representation of a sha256 hash `{0}`")]
+    BlobAddressInvalid(String),
+
+    /// This blob was not found.
+    #[error("no blob found at address `{0}`")]
+    BlobAddressNotFound(String),
+
+    /// A conversion for std:io:Error
+    #[error("io error")]
+    IoError(#[from] std::io::Error),
 }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod blobs;
 pub mod errors;
 pub mod mdns;
 pub mod networking;


### PR DESCRIPTION
It's now in utils::blobs. The API is `store()`, `get_stream()`, and `get_bytes()`. Made castaway use the library, which reduced it to pure http setup and response-building.

I took castaway's endpoints and copied them wholesale into serval-agent. The agent's versions of the endpoints are `GET /blobs/:id` and `PUT /blobs` because everybody writes http endpoint names differently and I pluralize the nouns. This is not meaningful, to be clear.

MORE EXCITINGLY, serval-agent also got a `GET /run/:blob_id` endpoint which probably really shouldn't be a GET but I'm making this PR fast instead of fixing that. This runs a stored binary! No input yet, because again, PRing for discussion first, and I think that requires a little thoughtful design first.