### PR TITLE
Respond to HEAD requests to /blobs/:addr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,6 +1687,7 @@ dependencies = [
  "owo-colors",
  "reqwest",
  "serde_json",
+ "thousands",
  "uuid",
 ]
 
@@ -2319,6 +2320,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "time"

--- a/pounce/Cargo.toml
+++ b/pounce/Cargo.toml
@@ -14,4 +14,5 @@ mdns-sd = { workspace = true }
 owo-colors = "3.5.0"
 reqwest = { version = "0.11.13", features = ["blocking", "brotli", "json", "multipart", "rustls"] }
 serde_json = "1.0.89"
+thousands = "0.2.0"
 uuid = { workspace = true }

--- a/serval-agent/src/api/storage.rs
+++ b/serval-agent/src/api/storage.rs
@@ -72,3 +72,21 @@ pub async fn store_blob(State(state): State<AppState>, body: Bytes) -> impl Into
         Err(_e) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     }
 }
+
+pub async fn has_blob(Path(blob_addr): Path<String>, State(state): State<AppState>) -> StatusCode {
+    // Yeah, I don't like this.
+    let state = state.lock().await;
+
+    match state.storage.has_blob(&blob_addr).await {
+        Ok(exists) => {
+            log::info!("Has blob?; exists={exists} addr={blob_addr}");
+            if exists {
+                StatusCode::OK
+            } else {
+                StatusCode::NOT_FOUND
+            }
+        }
+        Err(ServalError::BlobAddressInvalid(_)) => StatusCode::BAD_REQUEST,
+        Err(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}

--- a/serval-agent/src/main.rs
+++ b/serval-agent/src/main.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use axum::{
     extract::DefaultBodyLimit,
     middleware::{self},
-    routing::{get, post, put},
+    routing::{get, head, post, put},
     Router,
 };
 use dotenvy::dotenv;
@@ -46,6 +46,7 @@ async fn main() -> Result<()> {
         .route("/run/:addr", get(jobs::run_stored_job))
         .route("/blobs", put(storage::store_blob))
         .route("/blobs/:addr", get(storage::get_blob))
+        .route("/blobs/:addr", head(storage::has_blob))
         .route_layer(middleware::from_fn(clacks))
         .layer(DefaultBodyLimit::max(MAX_BODY_SIZE_BYTES))
         .with_state(state);

--- a/utils/src/blobs.rs
+++ b/utils/src/blobs.rs
@@ -47,6 +47,15 @@ impl BlobStore {
         Ok(stream)
     }
 
+    // Given a content address, determine whether we have a blob stored there or not.
+    pub async fn has_blob(&self, address: &str) -> Result<bool, ServalError> {
+        match self.get_stream(address).await {
+            Ok(_) => Ok(true),
+            Err(ServalError::BlobAddressNotFound(_)) => Ok(false),
+            Err(err) => Err(err),
+        }
+    }
+
     pub async fn get_bytes(&self, address: &str) -> Result<Vec<u8>, ServalError> {
         let stream = self.get_stream(address).await?;
         let mut reader = StreamReader::new(stream);

--- a/utils/src/blobs.rs
+++ b/utils/src/blobs.rs
@@ -56,6 +56,7 @@ impl BlobStore {
         }
     }
 
+    // A non-streaming way to retrieve a stored blob; please use get_stream instead wherever possible.
     pub async fn get_bytes(&self, address: &str) -> Result<Vec<u8>, ServalError> {
         let stream = self.get_stream(address).await?;
         let mut reader = StreamReader::new(stream);


### PR DESCRIPTION
Sending a HEAD request to the blob retrieval endpoint now gives you a succinct way of discovering whether a given blob has been stored before or not: 200 if it has, 404 if it hasn't. This lets us avoid sending a blob up to the storage system when it's already been stored.

I also added a few minor niceties to pounce while working on this:
- default to using the filename of the wasm binary rather than "unnamed"
- show the size of the binary + input payload in the output so people aren't surprised when big requests are slow to start (my 37+ MB object detection demo takes a solid 5–10 seconds, at least)
