### PR TITLE
Implement IntoResponse for ServalError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,6 +2567,7 @@ name = "utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
  "hex",
  "if-addrs 0.8.0",
  "log",

--- a/agent/src/api/storage.rs
+++ b/agent/src/api/storage.rs
@@ -28,32 +28,10 @@ pub async fn get_blob(
             log::info!("Serving blob; addr={}", &blob_addr);
             (headers, body).into_response()
         }
-        Err(e) => match e {
-            ServalError::BlobAddressInvalid(_) => {
-                log::warn!("Request for an invalid address; addr={}", blob_addr);
-                StatusCode::BAD_REQUEST.into_response()
-            }
-            ServalError::BlobAddressNotFound(_) => {
-                log::warn!("Blob not found; addr={blob_addr}");
-                (
-                    StatusCode::NOT_FOUND,
-                    format!("Blob {} not found", &blob_addr),
-                )
-                    .into_response()
-            }
-            ServalError::IoError(_) => {
-                log::warn!("i/o error reading blob; addr={blob_addr}; {:?}", e);
-                (
-                    StatusCode::NOT_FOUND,
-                    format!("Blob {} not found", &blob_addr),
-                )
-                    .into_response()
-            }
-            _ => {
-                log::warn!("unexpected error case; addr={blob_addr}; {:?}", e);
-                StatusCode::INTERNAL_SERVER_ERROR.into_response()
-            }
-        },
+        Err(e) => {
+            log::warn!("error reading blob; addr={}; error={}", blob_addr, e);
+            e.into_response()
+        }
     }
 }
 

--- a/storage/src/api.rs
+++ b/storage/src/api.rs
@@ -33,32 +33,10 @@ async fn get_blob(
             log::info!("Serving blob; addr={}", &blob_addr);
             (headers, body).into_response()
         }
-        Err(e) => match e {
-            ServalError::BlobAddressInvalid(_) => {
-                log::warn!("Request for an invalid address; addr={}", blob_addr);
-                StatusCode::BAD_REQUEST.into_response()
-            }
-            ServalError::BlobAddressNotFound(_) => {
-                log::warn!("Blob not found; addr={blob_addr}");
-                (
-                    StatusCode::NOT_FOUND,
-                    format!("Blob {} not found", &blob_addr),
-                )
-                    .into_response()
-            }
-            ServalError::IoError(_) => {
-                log::warn!("i/o error reading blob; addr={blob_addr}; {:?}", e);
-                (
-                    StatusCode::NOT_FOUND,
-                    format!("Blob {} not found", &blob_addr),
-                )
-                    .into_response()
-            }
-            _ => {
-                log::warn!("unexpected error case; addr={blob_addr}; {:?}", e);
-                StatusCode::INTERNAL_SERVER_ERROR.into_response()
-            }
-        },
+        Err(e) => {
+            log::warn!("error reading blob; addr={}; error={}", blob_addr, e);
+            e.into_response()
+        }
     }
 }
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -8,6 +8,7 @@ license = "BSD-2-Clause-Patent"
 
 [dependencies]
 anyhow.workspace = true
+axum.workspace = true
 hex = "0.4.3"
 if-addrs = "0.8.0"
 log.workspace = true


### PR DESCRIPTION
This cleans up a lot of the http machinery, at the expense of some specific logging. The logging does include the error text, so we can improve that if we want the details back.