### PR TITLE
Proxy storage requests to another node if we aren't in the storage role

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2097,6 +2097,7 @@ dependencies = [
  "env_logger 0.10.0",
  "http",
  "log",
+ "mdns-sd",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,6 +2081,8 @@ dependencies = [
  "reqwest",
  "serde_json",
  "thousands",
+ "tokio",
+ "utils",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,6 +2574,7 @@ dependencies = [
  "if-addrs 0.8.0",
  "log",
  "mdns-sd",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2096,6 +2096,7 @@ dependencies = [
  "engine",
  "env_logger 0.10.0",
  "http",
+ "hyper",
  "log",
  "mdns-sd",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ dotenvy = "0.15.6"
 env_logger = "0.10.0"
 log = "0.4.17"
 mdns-sd = { version = "0.5.9", default-features = false, features = ["async"] }
+reqwest = { version = "0.11.13",  default-features = false, features = ["brotli", "json", "rustls"] }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.89"
 tokio = { version = "1.22.0", features = ["full"] }

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -12,6 +12,7 @@ engine = { path = "../engine" }
 env_logger.workspace = true
 http = "0.2.8"
 log = "0.4.17"
+mdns-sd.workspace = true
 reqwest.workspace = true
 serde = { version = "1.0.149", features = ["serde_derive"] }
 serde_json.workspace = true

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -12,7 +12,7 @@ engine = { path = "../engine" }
 env_logger.workspace = true
 http = "0.2.8"
 log = "0.4.17"
-reqwest = { version = "0.11.13",  default-features = false, features = ["brotli", "json", "rustls"] }
+reqwest.workspace = true
 serde = { version = "1.0.149", features = ["serde_derive"] }
 serde_json.workspace = true
 tokio.workspace = true

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -11,6 +11,7 @@ dotenvy = "0.15.6"
 engine = { path = "../engine" }
 env_logger.workspace = true
 http = "0.2.8"
+hyper = "0.14.23"
 log = "0.4.17"
 mdns-sd.workspace = true
 reqwest.workspace = true

--- a/agent/src/api/mod.rs
+++ b/agent/src/api/mod.rs
@@ -1,9 +1,8 @@
 use anyhow::Result;
 use axum::{
-    extract::State,
     http::{Request, StatusCode},
     middleware::Next,
-    response::{IntoResponse, Response},
+    response::Response,
 };
 use http::header::HeaderValue;
 use serde::{Deserialize, Serialize};
@@ -15,6 +14,7 @@ use std::sync::Arc;
 use std::{collections::HashMap, path::PathBuf};
 
 pub mod jobs;
+pub mod proxy;
 pub mod storage;
 
 #[derive(Debug, Clone, Serialize)]
@@ -98,26 +98,4 @@ pub async fn clacks<B>(req: Request<B>, next: Next<B>) -> Result<Response, Statu
 /// Respond to ping. Useful for monitoring.
 pub async fn ping() -> String {
     "pong".to_string()
-}
-
-pub async fn proxy_unavailable_services<B>(
-    State(state): State<AppState>,
-    req: Request<B>,
-    next: Next<B>,
-) -> Result<Response, StatusCode> {
-    if req.uri().path().starts_with("/storage/") {
-        let state = state.lock().await;
-        if state.storage.is_none() {
-            log::info!(
-                "proxy_unavailable_services intecepting request; path={}",
-                req.uri().path()
-            );
-            // todo: In this case, we should proxy this request to another node that is advertising
-            // the serval_storage role. For now, let's just barf.
-            return Ok((StatusCode::SERVICE_UNAVAILABLE, "Storage not available").into_response());
-        }
-    }
-
-    let response = next.run(req).await;
-    Ok(response)
 }

--- a/agent/src/api/mod.rs
+++ b/agent/src/api/mod.rs
@@ -86,10 +86,12 @@ pub struct Envelope {
 /// Remember what is important.
 pub async fn clacks<B>(req: Request<B>, next: Next<B>) -> Result<Response, StatusCode> {
     let mut response = next.run(req).await;
-    response.headers_mut().append(
-        "X-Clacks-Overhead",
-        HeaderValue::from_static("GNU/Terry Pratchett"),
-    );
+    if !response.headers().contains_key("X-Clacks-Overhead") {
+        response.headers_mut().append(
+            "X-Clacks-Overhead",
+            HeaderValue::from_static("GNU/Terry Pratchett"),
+        );
+    }
     Ok(response)
 }
 

--- a/agent/src/api/proxy.rs
+++ b/agent/src/api/proxy.rs
@@ -21,7 +21,7 @@ pub async fn proxy_unavailable_services<B>(
         let state = state.lock().await;
         if state.storage.is_none() {
             log::info!(
-                "proxy_unavailable_services intecepting request; path={}",
+                "proxy_unavailable_services intercepting request; path={}",
                 path,
             );
 

--- a/agent/src/api/proxy.rs
+++ b/agent/src/api/proxy.rs
@@ -5,6 +5,9 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
+use http::header::{CONTENT_LENGTH, EXPECT, HOST};
+use mdns_sd::ServiceInfo;
+use utils::{errors::ServalError, mdns::discover_service};
 
 use super::*;
 
@@ -13,19 +16,117 @@ pub async fn proxy_unavailable_services<B>(
     req: Request<B>,
     next: Next<B>,
 ) -> Result<Response, StatusCode> {
-    if req.uri().path().starts_with("/storage/") {
+    let path = req.uri().path();
+    if path.starts_with("/storage/") {
         let state = state.lock().await;
         if state.storage.is_none() {
             log::info!(
                 "proxy_unavailable_services intecepting request; path={}",
-                req.uri().path()
+                path,
             );
-            // todo: In this case, we should proxy this request to another node that is advertising
-            // the serval_storage role. For now, let's just barf.
-            return Ok((StatusCode::SERVICE_UNAVAILABLE, "Storage not available").into_response());
+
+            let Ok(resp) = proxy_request_to_service(&req, "_serval_storage").await else {
+                // Welp, not much we can do
+                return Ok((StatusCode::SERVICE_UNAVAILABLE, "Storage not available").into_response());
+            };
+
+            return Ok(resp);
         }
     }
 
     let response = next.run(req).await;
     Ok(response)
+}
+
+// proxies the given request to to the first node that we discover that is advertising the given
+// service. in the future, we may keep a list of known nodes for a given service so we can avoid
+// running the discovery process for every proxy request.
+async fn proxy_request_to_service<B>(
+    req: &Request<B>,
+    service_name: &str,
+) -> Result<Response, ServalError> {
+    let node_info = discover_service(service_name).await.map_err(|err| {
+        log::warn!("proxy_unavailable_services failed to find a node offering the service; service={service_name}; err={err:?}");
+        err
+    })?;
+
+    let result = proxy_request_to_other_node(req, &node_info).await;
+    result
+}
+
+async fn proxy_request_to_other_node<B>(
+    req: &Request<B>,
+    info: &ServiceInfo,
+) -> Result<Response, ServalError> {
+    let host = info.get_addresses().iter().next().unwrap(); // unwrap is safe because discover_service will never return a service without addresses
+    let port = info.get_port();
+    let path = req.uri().path();
+    let query = req
+        .uri()
+        .query()
+        .map(|qs| format!("?{qs}"))
+        .unwrap_or_else(|| "".to_string());
+    let url = format!("http://{host}:{port}{path}{query}");
+    let mut inner_req = reqwest::Client::new().request(req.method().clone(), url);
+
+    // Copy over the headers, modulo a few that are only relevant to the original request
+    for (k, v) in req.headers().iter() {
+        if k == CONTENT_LENGTH || k == EXPECT || k == HOST {
+            continue;
+        }
+        inner_req = inner_req.header(k, v);
+    }
+    inner_req = inner_req.header(
+        "Serval-Proxied-For",
+        "<todo: put instance_id here once it exists in AppState>",
+    );
+
+    // Actually send the request
+    inner_req
+        .send()
+        .await
+        .map(reqwest_response_to_axum_response)?
+        .await
+        .map(|mut resp| {
+            resp.headers_mut().append(
+                "Serval-Proxied-From",
+                "<todo: put instance_id from `info`'s properties here>"
+                    .parse()
+                    .unwrap(),
+            );
+            resp
+        })
+        .map_err(|err| {
+            log::warn!("Failed to proxy request to other node; node={host}:{port}; err={err:?}");
+            err
+        })
+}
+
+async fn reqwest_response_to_axum_response(
+    reqwest_resp: reqwest::Response,
+) -> Result<Response, ServalError> {
+    let inner_status = reqwest_resp.status();
+    let inner_headers = reqwest_resp.headers().to_owned();
+    let addr = reqwest_resp.remote_addr();
+    let inner_body = reqwest_resp.bytes().await.map_err(|err| {
+        log::warn!("Failed to read response from proxy node; addr={addr:?}; err={err:?}");
+        err
+    })?;
+    let mut axum_resp = (inner_status, inner_body).into_response();
+
+    // Remove any headers that axum hallucinated into the response if the reqwest response has them;
+    // in particular, it will set a content-type of application/octet-stream, which we don't need if
+    // the reqwest_resp has a content-type header of its own.
+    let headers = axum_resp.headers_mut();
+    for k in inner_headers.keys() {
+        if inner_headers.contains_key(k) {
+            headers.remove(k);
+        }
+    }
+
+    for (k, v) in inner_headers.iter() {
+        headers.append(k, v.clone());
+    }
+
+    Ok(axum_resp)
 }

--- a/agent/src/api/proxy.rs
+++ b/agent/src/api/proxy.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use axum::{
+    extract::State,
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+
+use super::*;
+
+pub async fn proxy_unavailable_services<B>(
+    State(state): State<AppState>,
+    req: Request<B>,
+    next: Next<B>,
+) -> Result<Response, StatusCode> {
+    if req.uri().path().starts_with("/storage/") {
+        let state = state.lock().await;
+        if state.storage.is_none() {
+            log::info!(
+                "proxy_unavailable_services intecepting request; path={}",
+                req.uri().path()
+            );
+            // todo: In this case, we should proxy this request to another node that is advertising
+            // the serval_storage role. For now, let's just barf.
+            return Ok((StatusCode::SERVICE_UNAVAILABLE, "Storage not available").into_response());
+        }
+    }
+
+    let response = next.run(req).await;
+    Ok(response)
+}

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -62,6 +62,7 @@ async fn main() -> Result<()> {
         ),
     };
 
+    // todo: add instance_id (a UUID) to RunnerState
     let state = Arc::new(Mutex::new(RunnerState::new(blob_path.clone())?));
 
     const MAX_BODY_SIZE_BYTES: usize = 100 * 1024 * 1024;

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -16,7 +16,7 @@ use axum::{
 };
 use dotenvy::dotenv;
 use tokio::sync::Mutex;
-use utils::mdns::advertise_service;
+use utils::{mdns::advertise_service, networking::find_nearest_port};
 
 use std::net::SocketAddr;
 use std::{path::PathBuf, sync::Arc};
@@ -38,7 +38,8 @@ async fn main() -> Result<()> {
 
     let host = std::env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
     let port: u16 = std::env::var("PORT")
-        .unwrap_or_else(|_| "8100".to_string())
+        .map(Ok)
+        .unwrap_or_else(|_| find_nearest_port(8100).map(|port| port.to_string()))?
         .parse()?;
     let storage_role = match &std::env::var("STORAGE_ROLE").unwrap_or_else(|_| "auto".to_string())[..]
     {

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<()> {
         // end optional endpoints
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
-            proxy_unavailable_services,
+            proxy::proxy_unavailable_services,
         ))
         .route_layer(middleware::from_fn(clacks))
         .layer(DefaultBodyLimit::max(MAX_BODY_SIZE_BYTES))

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,4 +15,6 @@ owo-colors = "3.5.0"
 reqwest = { version = "0.11.13", features = ["blocking", "brotli", "json", "multipart", "rustls"] }
 serde_json.workspace = true
 thousands = "0.2.0"
-uuid.workspace = true
+tokio.workspace = true
+utils = { path = "../utils" }
+uuid = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,4 +17,4 @@ serde_json.workspace = true
 thousands = "0.2.0"
 tokio.workspace = true
 utils = { path = "../utils" }
-uuid = { workspace = true }
+uuid.workspace = true

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -18,5 +18,6 @@ thiserror = "1.0.38"
 tokio.workspace = true
 tokio-util.workspace = true
 wasi-common.workspace = true
+reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/utils/src/errors.rs
+++ b/utils/src/errors.rs
@@ -46,6 +46,9 @@ pub enum ServalError {
 
     #[error("mdns service was not found before timeout")]
     ServiceNotFound,
+
+    #[error("reqwest error")]
+    ReqwestError(#[from] reqwest::Error),
 }
 
 use axum::http::StatusCode;
@@ -70,6 +73,7 @@ impl IntoResponse for ServalError {
             ServalError::BlobAddressNotFound(_) => StatusCode::NOT_FOUND,
             ServalError::IoError(_) => StatusCode::NOT_FOUND,
             ServalError::ServiceNotFound => StatusCode::NOT_FOUND,
+            ServalError::ReqwestError(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
 
         (status, self.to_string()).into_response()

--- a/utils/src/errors.rs
+++ b/utils/src/errors.rs
@@ -43,6 +43,9 @@ pub enum ServalError {
     /// A conversion for std:io:Error
     #[error("io error")]
     IoError(#[from] std::io::Error),
+
+    #[error("mdns service was not found before timeout")]
+    ServiceNotFound,
 }
 
 use axum::http::StatusCode;
@@ -66,6 +69,7 @@ impl IntoResponse for ServalError {
             ServalError::BlobAddressInvalid(_) => StatusCode::BAD_REQUEST,
             ServalError::BlobAddressNotFound(_) => StatusCode::NOT_FOUND,
             ServalError::IoError(_) => StatusCode::NOT_FOUND,
+            ServalError::ServiceNotFound => StatusCode::NOT_FOUND,
         };
 
         (status, self.to_string()).into_response()

--- a/utils/src/futures.rs
+++ b/utils/src/futures.rs
@@ -1,0 +1,17 @@
+use std::future::Future;
+
+use tokio::runtime::Runtime;
+
+pub fn get_future_sync<F: Future>(future: F) -> F::Output {
+    let runtime = match tokio::runtime::Handle::try_current() {
+        // there's already an active Tokio runtime
+        Ok(runtime) => runtime,
+
+        // there is not already an active Tokio runtime; create one just for this call
+        // todo: we could create one and store it for usage by future invocations, but let's cross
+        // that bridge when we burn it.
+        Err(_) => Runtime::new().unwrap().handle().to_owned(),
+    };
+
+    runtime.block_on(future)
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod blobs;
 pub mod errors;
+pub mod futures;
 pub mod mdns;
 pub mod networking;
 pub mod structs;

--- a/utils/src/mdns.rs
+++ b/utils/src/mdns.rs
@@ -1,5 +1,7 @@
-use mdns_sd::{ServiceDaemon, ServiceInfo};
+use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
+use tokio::time::timeout as tokio_timeout;
 
+use std::time::Duration;
 use std::{collections::HashMap, net::Ipv4Addr};
 
 use crate::errors::ServalError;
@@ -34,4 +36,52 @@ pub fn advertise_service(
     mdns.register(service_info)?;
 
     Ok(())
+}
+
+pub async fn discover_service(service_name: &str) -> Result<ServiceInfo, ServalError> {
+    discover_service_with_timeout(service_name, Duration::from_secs(30)).await
+}
+
+pub async fn discover_service_with_timeout(
+    service_name: &str,
+    timeout_duration: Duration,
+) -> Result<ServiceInfo, ServalError> {
+    let mdns = ServiceDaemon::new()?;
+    let service_type = format!("{service_name}._tcp.local.");
+    let receiver = mdns.browse(&service_type)?;
+
+    // note: we could distinguish between "not found because `receiver` closed its channel and
+    // stopped sending us events" and "not found because `max_wait` has elapsed", but it doesn't
+    // seem obviously to be worth bothering with
+
+    let discover_service = async {
+        while let Ok(event) = receiver.recv_async().await {
+            let ServiceEvent::ServiceResolved(info) = event else {
+                // We don't care about other events here
+                continue;
+            };
+            if info.get_addresses().is_empty() {
+                // This should never happen, but let's check here so all consumer code can just
+                // info.get_addresses().get(0).upwrap() without needing to worry about it exploding.
+                continue;
+            }
+            // tell mdns to stop browsing and consume its SearchStopped message, otherwise we'll get
+            // a "sending on a closed channel" error in the console when mdns goes out of scope
+            let _ = mdns.stop_browse(&service_type);
+            while let Ok(event) = receiver.recv() {
+                if matches!(event, ServiceEvent::SearchStopped(_)) {
+                    break;
+                }
+            }
+
+            return Ok(info);
+        }
+        Err(ServalError::ServiceNotFound)
+    };
+
+    let Ok(resp) = tokio_timeout(timeout_duration, discover_service).await else {
+        return Err(ServalError::ServiceNotFound);
+    };
+
+    resp
 }


### PR DESCRIPTION
This expands the `proxy_unavailable_services` stub that we added earlier in the week to actually implement proxying, rather than returning a 503 error. When we get a request under the `/storage/` namespace, we now use mdns to look for a node advertising the `_serval_storage` role, forward a copy of the request to them, and pass the result back. With a handful of exceptions, all of the headers from the original are passed through unchanged, so non-trivial requests that make use of things like cookies should theoretically Just Work™.

There's no retry logic if things don't work for whatever reason, but I think that's ok (especially at this stage). If anything goes wrong trying to proxy the request to another node, it's surfaced to the original requestor as a [503 (service unavailable)](https://http.cat/503) error.

## Testing

:one: Spin up two instances, making one the storage node and one not:

- `PORT=8101 STORAGE_ROLE=always cargo run --bin serval-agent`
- `PORT=8100 STORAGE_ROLE=never cargo run --bin serval-agent`

(I'm hard-coding the port numbers here so the order I start these instances up doesn't change which port number is storage vs. not.)

:two: Make a request to the storage node

````sh
$ curl -D - localhost:8101/storage/blobs -X PUT -sT README.md
HTTP/1.1 100 Continue

HTTP/1.1 200 OK
content-type: text/plain; charset=utf-8
content-length: 64
x-clacks-overhead: GNU/Terry Pratchett
date: Fri, 13 Jan 2023 21:41:01 GMT

7781ffbc12ffcec30129d37c63e0576a34c14a39d2ff71a42f2848948b7e9c61%                                                                                              
````

In particular, note the lack of a `serval-proxied-from` header in the response.

:three: Make a request to the non-storage node

````sh
$ curl -D - localhost:8100/storage/blobs -X PUT -sT README.md
HTTP/1.1 200 OK
content-type: text/plain; charset=utf-8
content-length: 64
x-clacks-overhead: GNU/Terry Pratchett
date: Fri, 13 Jan 2023 21:40:53 GMT
serval-proxied-from: <todo: put instance_id from `info`'s properties here>

e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855%
````

Behold the gentle glory of the `serval-proxied-from` header, and if you look at the log output of the non-storage node, you'll see this:
````
[2023-01-13T22:22:37Z INFO  serval_agent::api::proxy] proxy_unavailable_services intercepting request; path=/storage/blobs
````