### PR TITLE
Host functions & better error messages

### DIFF
--- a/agent/src/api/jobs.rs
+++ b/agent/src/api/jobs.rs
@@ -41,20 +41,19 @@ pub async fn incoming(state: State<AppState>, mut multipart: Multipart) -> Respo
         }
     }
 
-    if binary.is_none() {
+    let Some(binary) = binary else {
         return (
             StatusCode::BAD_REQUEST,
             "no wasm executable data provided!".to_string(),
         )
             .into_response();
-    }
+    };
 
     let envelope = envelope.unwrap_or(Envelope {
         name: "unknown".to_string(),
         description: "unknown job description".to_string(),
     });
     let metadata: JobMetadata = JobMetadata::from(envelope);
-    let binary = binary.unwrap();
     log::info!(
         "received WASM job; name={}; executable length={}; input length={}",
         metadata.name,

--- a/utils/src/errors.rs
+++ b/utils/src/errors.rs
@@ -28,7 +28,7 @@ pub enum ServalError {
     AbnormalWasmExit { result: WasmResult },
 
     // A conversion for anyhow::Error
-    #[error("an anyhow! error")]
+    #[error("anyhow::Error: {0}")]
     AnyhowError(#[from] anyhow::Error),
 
     /// The caller has attempted to load an object from the blob store with an invalid address.
@@ -40,13 +40,13 @@ pub enum ServalError {
     BlobAddressNotFound(String),
 
     /// A conversion for std:io:Error
-    #[error("io error")]
+    #[error("std::io::Error: {0}")]
     IoError(#[from] std::io::Error),
 
     #[error("mdns service was not found before timeout")]
     ServiceNotFound,
 
-    #[error("reqwest error")]
+    #[error("reqwest::Error: {0}")]
     ReqwestError(#[from] reqwest::Error),
 }
 


### PR DESCRIPTION
As discussed in Slack, this improves the derived ServalError variants to actually have useful error messages when written to log files or what-have-you.

Before: ```"an anyhow! error"```
After: ```"anyhow::Error: unknown import: `serval::add` has not been defined"```

This was done in the service of trying to figure out how to expose functions to the WASM jobs we run, which was trivial (of course) but surprisingly hard to figure out (I blame the lack of coffee). This PR adds a useless function to add two `i32`s together, which will have to do until we have a proper host SDK of some kind. The [call-a-host-function](https://github.com/servals/wasm-samples/tree/main/call-a-host-function) sample code makes use of this.

Despite the uselessness of their current form, both of these exist to be living documentation of how to expose things to jobs and how to import things from the job runner.