### PR TITLE
Namespace all endpoints as /v1

### DIFF
--- a/agent/src/api/mod.rs
+++ b/agent/src/api/mod.rs
@@ -5,86 +5,10 @@ use axum::{
     response::Response,
 };
 use http::header::HeaderValue;
-use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex;
-use utils::{blobs::BlobStore, errors::ServalError};
-use uuid::Uuid;
 
-use std::sync::Arc;
-use std::{collections::HashMap, path::PathBuf};
-
-pub mod jobs;
-pub mod proxy;
-pub mod storage;
-
-#[derive(Debug, Clone, Serialize)]
-pub struct RunnerState {
-    instance_id: Uuid,
-    storage: Option<BlobStore>,
-    jobs: HashMap<String, JobMetadata>,
-    total: usize,
-    errors: usize,
-}
-
-impl RunnerState {
-    pub fn new(instance_id: Uuid, blob_path: Option<PathBuf>) -> Result<Self, ServalError> {
-        let storage = match blob_path {
-            Some(path) => Some(BlobStore::new(path)?),
-            None => None,
-        };
-
-        Ok(RunnerState {
-            instance_id,
-            storage,
-            total: 0,
-            errors: 0,
-            jobs: HashMap::new(),
-        })
-    }
-}
-
-pub type AppState = Arc<Mutex<RunnerState>>;
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct JobMetadata {
-    id: Uuid,
-    name: String,
-    description: String,
-    status_url: String, // for the moment
-    result_url: String, // for the moment
-}
-
-impl JobMetadata {
-    pub fn new(name: String, description: String) -> Self {
-        let id = Uuid::new_v4();
-        Self {
-            id,
-            name,
-            description,
-            status_url: format!("/jobs/{}/status", id),
-            result_url: format!("/jobs/{}/result", id),
-        }
-    }
-}
-
-impl From<Envelope> for JobMetadata {
-    fn from(envelope: Envelope) -> Self {
-        let id = Uuid::new_v4();
-        Self {
-            id,
-            name: envelope.name.clone(),
-            description: envelope.description,
-            status_url: format!("/jobs/{}/status", id),
-            result_url: format!("/jobs/{}/result", id),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct Envelope {
-    name: String,
-    description: String,
-}
+pub mod v1;
+// Follow this pattern for additional major versions. E.g.,
+// pub mod v2;
 
 /// Remember what is important.
 pub async fn clacks<B>(req: Request<B>, next: Next<B>) -> Result<Response, StatusCode> {

--- a/agent/src/api/v1/mod.rs
+++ b/agent/src/api/v1/mod.rs
@@ -1,0 +1,6 @@
+use http::header::HeaderValue;
+use uuid::Uuid;
+
+pub mod jobs;
+pub mod proxy;
+pub mod storage;

--- a/agent/src/api/v1/proxy.rs
+++ b/agent/src/api/v1/proxy.rs
@@ -13,6 +13,7 @@ use utils::{
 };
 
 use super::*;
+use crate::structures::AppState;
 
 pub async fn proxy_unavailable_services<B>(
     State(state): State<AppState>,

--- a/agent/src/api/v1/storage.rs
+++ b/agent/src/api/v1/storage.rs
@@ -7,7 +7,7 @@ use axum::{
 
 use utils::errors::ServalError;
 
-use super::*;
+use crate::structures::AppState;
 
 pub async fn get_blob(
     Path(blob_addr): Path<String>,

--- a/agent/src/structures/mod.rs
+++ b/agent/src/structures/mod.rs
@@ -1,0 +1,95 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use utils::{blobs::BlobStore, errors::ServalError};
+use uuid::Uuid;
+
+use std::sync::Arc;
+use std::{collections::HashMap, path::PathBuf};
+
+/// Our application state. Fields are public for now but we'll want to fix that.
+#[derive(Debug, Clone, Serialize)]
+pub struct RunnerState {
+    pub instance_id: Uuid,
+    pub storage: Option<BlobStore>,
+    pub jobs: HashMap<String, JobMetadata>,
+    pub total: usize,
+    pub errors: usize,
+}
+
+impl RunnerState {
+    pub fn new(instance_id: Uuid, blob_path: Option<PathBuf>) -> Result<Self, ServalError> {
+        let storage = match blob_path {
+            Some(path) => Some(BlobStore::new(path)?),
+            None => None,
+        };
+
+        Ok(RunnerState {
+            instance_id,
+            storage,
+            total: 0,
+            errors: 0,
+            jobs: HashMap::new(),
+        })
+    }
+}
+
+pub type AppState = Arc<Mutex<RunnerState>>;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JobMetadata {
+    id: Uuid,
+    name: String,
+    description: String,
+    status_url: String, // for the moment
+    result_url: String, // for the moment
+}
+
+impl JobMetadata {
+    pub fn new(name: String, description: String) -> Self {
+        let id = Uuid::new_v4();
+        Self {
+            id,
+            name,
+            description,
+            status_url: format!("/jobs/{}/status", id),
+            result_url: format!("/jobs/{}/result", id),
+        }
+    }
+
+    pub fn id(&self) -> &Uuid {
+        &self.id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl From<Envelope> for JobMetadata {
+    fn from(envelope: Envelope) -> Self {
+        let id = Uuid::new_v4();
+        Self {
+            id,
+            name: envelope.name.clone(),
+            description: envelope.description,
+            status_url: format!("/jobs/{}/status", id),
+            result_url: format!("/jobs/{}/result", id),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Envelope {
+    name: String,
+    description: String,
+}
+
+impl Default for Envelope {
+    fn default() -> Self {
+        Self {
+            name: "unknown".to_string(),
+            description: "unknown job description".to_string(),
+        }
+    }
+}

--- a/agent/src/structures/mod.rs
+++ b/agent/src/structures/mod.rs
@@ -52,8 +52,8 @@ impl JobMetadata {
             id,
             name,
             description,
-            status_url: format!("/jobs/{}/status", id),
-            result_url: format!("/jobs/{}/result", id),
+            status_url: format!("/v1/jobs/{}/status", id),
+            result_url: format!("/v1/jobs/{}/result", id),
         }
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -78,7 +78,7 @@ fn build_url(path: String) -> String {
     let baseurl = baseurl
         .as_ref()
         .expect("build_url called while SERVAL_NODE_URL is None");
-    format!("{baseurl}/{path}")
+    format!("{baseurl}/v1/{path}")
 }
 
 /// Convenience function to read an input wasm binary either from a pathbuf or from stdin.


### PR DESCRIPTION
Did this in the cli, the endpoint uris, and the rust modules. Doing this any later in development will only get more annoying, so now is the time.